### PR TITLE
Fix: Linux app icon not displaying

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,6 +53,7 @@ mac:
         - universal
 linux:
   artifactName: ${os}-${name}-${version}-linux.${ext}
+  icon: build/icon.icns
   target:
     - target: deb
       arch:


### PR DESCRIPTION
This PR addresses an issue where the application icon was not displaying at all on Linux desktop environments.

**Problem Identified:**
The default icon.png used for Linux builds, which is 320x320px, was causing the application icon to be entirely absent on Linux systems. While testing, I found that using a 512x512px icon allowed it to display, but the final .deb package still only included this single icon size. This prevents desktop environments from properly registering or displaying the icon across various contexts (e.g., dock, taskbar, application launcher), leading to an absent or incorrectly sized icon.

**Solution Implemented:**
I've modified the electron-builder.yml configuration to use the icon.icns file as the primary icon source specifically for Linux builds. This approach leverages electron-builder's capability to generate multiple icon sizes from a single, high-resolution .icns source. This ensures that the .deb package contains a comprehensive set of icon sizes, allowing Linux desktop environments to correctly display the application icon.

**Future Improvements (Suggestions):**
To further enhance icon quality and flexibility, I suggest considering the following:

- Update icon.icns: Regenerate icon.icns to include a 512x512px (or higher) resolution icon, as the current one appears to be limited to 256x256px as its maximum size.
- Replace icon.png: Update the icon.png source file to a native 512x512px (or higher) resolution image. (I haven't pushed my modified version as it was simply an upscaled 320x320px image, which isn't ideal for quality).
- Optional: Provide pre-rendered PNGs: For ultimate control over icon quality at various sizes, consider placing pre-rendered PNG icons (e.g., 16x16, 32x32, 48x48, 64x64, 128x128, 256x256, 512x512) directly into a build assets folder (e.g., build/icons). This can ensure pixel-perfect rendering for each specific size.