### PR TITLE
Fix: Prepare configuration for macOS code signing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MIRU_SUBMODULES_PAT }}
           GH_TOKEN: ${{ secrets.MIRU_SUBMODULES_PAT }}
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # CSC_LINK: ${{ secrets.APPLE_SIGNING_CERT }}
-          # API_KEY: ${{ secrets.APPLE_API_KEY }}
-          # APPLE_API_KEY: apple.p8
-          # APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          # APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # CSC_KEY_PASSWORD: ${{ secrets.APPLE_SIGNING_PASSWORD }}
+          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         run: npm run build:publish

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -3,12 +3,10 @@
 <plist version="1.0">
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
-    <true />
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true />
+    <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true />
+    <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
-    <true />
+    <true/>
   </dict>
 </plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -46,7 +46,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
+  notarize: true
   target:
     - target: default
       arch:


### PR DESCRIPTION
This PR contains some changes needed to make macOS/Apple signing possible.

`com.apple.security.cs.allow-unsigned-executable-memory` was removed from `entitlements.mac.plist` as it's been discouraged as of electron 12, and also caused problems with builds because of it. Doesn't break functionality.

workflow still sees keys macOS specific env vars commented out but are updated to the correct ones. All of them are required.

Lastly notarization has been enabled for macOS builds in order to sign the build.